### PR TITLE
Add persistence layer to keep data, in yaml format fix issue #10

### DIFF
--- a/core.py
+++ b/core.py
@@ -13,6 +13,24 @@ import os
 
 from uml import CreateUML, UMLStepSetup
 
+
+def deep_to_dict(obj):
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    if isinstance(obj, dict):
+        return {k: deep_to_dict(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [deep_to_dict(x) for x in obj]
+
+    # Aquí aplicamos tu filtro para objetos personalizados
+    if hasattr(obj, "__dict__"):
+        return {
+            k: deep_to_dict(v)
+            for k, v in vars(obj).items()
+            if not callable(v) and not k.startswith('_')
+        }
+    return str(obj) # Último recurso
+
 def analyze_corda_log(log_file_path: str, what_to_collect:CordaObject.Type=None, datainfo=None) -> dict:
     """
     Analiza un archivo de log de Corda y devuelve un diccionario con:
@@ -106,36 +124,40 @@ def analyze_corda_log(log_file_path: str, what_to_collect:CordaObject.Type=None,
         ]
         payload["summary"]["total_parties"] = len(parties)
         payload["summary"]["detected_roles"] = detected_roles
-        payload["results"]["parties"] = parties
+        payload["results"][CordaObject.Type.PARTY.value] = parties
 
     if collect_refIds:
-        flows = []
-        transactions = []
+        flows = {}
+        transactions = {}
+        # Transform CordaObject into a dictionary for serialization
         for item in file_to_analyse.get_all_unique_results(CordaObject.Type.FLOW_AND_TRANSACTIONS, True) or []:
             ref_id = item.get_reference_id()
+            item_dict = deep_to_dict(item)
             if item.get_type() == "FLOW":
-                flows.append(ref_id)
+                flows[f'{ref_id}']=item_dict
             elif item.get_type() == "TRANSACTION":
-                transactions.append(ref_id)
-
+                transactions[f'{ref_id}'] =item_dict
+        # Put all content of flows and transactions into same buket; each corda object has its type and can be
+        # easily identified.
+        fnt = {**flows, **transactions}
         payload["summary"]["total_transactions"] = len(transactions)
         payload["summary"]["total_flows"]= len(flows)
 
-        payload["results"]["flows"] = flows
-        payload["results"]["transactions"] = transactions
+        payload["results"][CordaObject.Type.FLOW_AND_TRANSACTIONS.value] = fnt
 
     if special_blocks and  special_blocks.collected_blocks:
-        payload["results"]["specialblocks"] = {
+        payload["results"][CordaObject.Type.SPECIAL_BLOCKS.value] = {
             "collected_blocktypes_types": special_blocks.get_collected_block_types(),
             "defined_blocktypes": special_blocks.get_defined_block_types(),
             "collected_blocktypes": special_blocks.get_all_content()
         }
+        payload['summary'][CordaObject.Type.SPECIAL_BLOCKS.value] = special_blocks.get_collected_block_types()
 
     if collect_errors:
         collect_errors.collected_errors = file_to_analyse.get_all_unique_results(CordaObject.Type.ERROR_ANALYSIS)
         # payload["Error-log"] = collect_errors.get_error_category()
-        payload["results"]['Error-Log'] = collect_errors.get_all_content()
-        payload['summary']['Error-log'] =  collect_errors.get_error_summary()
+        payload["results"][CordaObject.Type.ERROR_ANALYSIS.value] = collect_errors.get_all_content()
+        payload['summary'][CordaObject.Type.ERROR_ANALYSIS.value] = collect_errors.get_error_summary()
 
 
     # 6. Devolver resultado estructurado
@@ -255,6 +277,16 @@ class DataInfo:
 
         CUSTOMER = 'customer'
         TICKET = 'ticket'
+        CORDA_VERSION = "corda_version"
+        JAVA_VERSION = "java_version"
+        OS = "operating_system"
+        RUNNING_ON_DOCKER = "running_on_docker"
+        RUNNING_ON_K8S = "running_on_k8s"
+        K8S_VERSION = "k8s_version"
+        DOCKER_VERSION = "docker_version"
+        ENVIRONMENT = "environment"
+        DESCRIPTION = "description"
+        ISSUE = "issue"
 
     def __init__(self):
         """

--- a/drivers/yaml_driver.py
+++ b/drivers/yaml_driver.py
@@ -21,6 +21,7 @@ class YamlDataDriver(DataDriver):
         self.parties_dir = None
         self.blocks_dir = None
         self.errors_dir = None
+        self.summary = None
         self.cache = {}  # Opcional: cache para mejorar rendimiento
 
     def connect(self, **config):
@@ -36,14 +37,18 @@ class YamlDataDriver(DataDriver):
         self.parties_dir = self.data_dir / "parties"
         self.blocks_dir = self.data_dir / "blocks"
         self.errors_dir = self.data_dir / "errors"
+        self.summary = config.get("summary")
 
         # Crear directorios
         for dir_path in [self.entities_dir, self.parties_dir, self.blocks_dir, self.errors_dir]:
-            dir_path.mkdir(parents=True, exist_ok=True)
+            if not os.path.exists(dir_path):
+                dir_path.mkdir(parents=True, exist_ok=True)
 
         # Cargar cache si está habilitada
         if config.get('cache_enabled', False):
             self._load_cache()
+
+        self.save_summary()
 
     def _load_cache(self):
         """Cargar datos en memoria para acceso rápido"""
@@ -97,16 +102,24 @@ class YamlDataDriver(DataDriver):
                     objects.append(self._dict_to_corda_object(data))
         return objects
 
-    def save_corda_object(self, corda_obj: CordaObject):
-        entity_file = self.entities_dir / f"entity_{corda_obj.reference_id}.yaml"
-        data = self._corda_object_to_dict(corda_obj)
+    def save_corda_object(self, corda_obj):
+        """
+        Save corda object data as JSON file
+        :param corda_obj: either a CordaObject class or a dictionary
+        :return:
+        """
 
+        if isinstance(corda_obj, CordaObject ):
+            data = self._corda_object_to_dict(corda_obj)
+        else:
+            data = corda_obj
+        entity_file = self.entities_dir / f"entity_{data['reference_id']}.yaml"
         with open(entity_file, 'w', encoding='utf-8') as f:
             yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
         # Actualizar cache
         if hasattr(self, 'cache'):
-            self.cache[f"entity_{corda_obj.reference_id}"] = corda_obj
+            self.cache[f"entity_{data['reference_id']}"] = corda_obj
 
     def save_corda_objects(self, corda_objects: List[CordaObject]):
         for obj in corda_objects:
@@ -130,10 +143,13 @@ class YamlDataDriver(DataDriver):
                 return self._dict_to_party(data)
         return None
 
-    def save_party(self, party: Party):
-        party_file = self.parties_dir / f"{party.name}.yaml"
-        data = self._party_to_dict(party)
+    def save_party(self, party):
 
+        if isinstance(party, Party):
+            data = self._party_to_dict(party)
+        else:
+            data = party
+        party_file = self.parties_dir / f"{data['name']}.yaml"
         with open(party_file, 'w', encoding='utf-8') as f:
             yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
@@ -155,10 +171,23 @@ class YamlDataDriver(DataDriver):
                 blocks.append(self._dict_to_block_item(data))
         return blocks
 
-    def save_block_item(self, block_item: BlockItems):
-        block_file = self.blocks_dir / f"block_{block_item.reference}_{block_item.type}.yaml"
-        data = self._block_item_to_dict(block_item)
+    def save_summary(self):
+        """
+        Save summary for received payload
+        :return:
+        """
+        with open(f"{self.data_dir}/summary.yaml", 'w', encoding='utf-8') as f:
+            yaml.dump(self.summary, f, allow_unicode=True, default_flow_style=False)
 
+
+    def save_block_item(self, block_item):
+
+        if isinstance(block_item, BlockItems):
+            data = self._block_item_to_dict(block_item)
+        else:
+            data = block_item
+
+        block_file = self.blocks_dir / f"block_{data['reference']}_{data['type']}.yaml"
         with open(block_file, 'w', encoding='utf-8') as f:
             yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
@@ -166,7 +195,7 @@ class YamlDataDriver(DataDriver):
 
     def get_errors_by_category(self, category: str) -> List[Error]:
         errors = []
-        for error_file in self.errors_dir.glob(f"error_*_{category}.yaml"):
+        for error_file in self.errors_dir.glob(f"error_{category}_*.yaml"):
             with open(error_file, 'r', encoding='utf-8') as f:
                 data = yaml.safe_load(f)
                 errors.append(self._dict_to_error(data))
@@ -174,7 +203,7 @@ class YamlDataDriver(DataDriver):
 
     def get_errors_by_type(self, error_type: str) -> List[Error]:
         errors = []
-        for error_file in self.errors_dir.glob(f"error_{error_type}_*.yaml"):
+        for error_file in self.errors_dir.glob(f"error_*_{error_type}.yaml"):
             with open(error_file, 'r', encoding='utf-8') as f:
                 data = yaml.safe_load(f)
                 errors.append(self._dict_to_error(data))
@@ -188,10 +217,14 @@ class YamlDataDriver(DataDriver):
                 errors.append(self._dict_to_error(data))
         return errors
 
-    def save_error(self, error: Error):
-        error_file = self.errors_dir / f"error_{error.type}_{error.category}.yaml"
-        data = self._error_to_dict(error)
+    def save_error(self, error):
 
+        if isinstance(error, Error):
+            data = self._error_to_dict(error)
+        else:
+            data = error
+
+        error_file = self.errors_dir / f"error_{data['category']}_{data['type']}_{data['reference_id']}.yaml"
         with open(error_file, 'w', encoding='utf-8') as f:
             yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 

--- a/error_log_analysis.py
+++ b/error_log_analysis.py
@@ -123,18 +123,23 @@ class ErrorAnalysis:
         :return:
         """
 
-        return_list = {}
-
+        return_list = {
+            "total_errors": 0,
+            "error_list": {}
+        }
+        total_errors = 0
         if not self.category_list:
             self._classify_errors()
 
         for each_category in self.category_list:
             if each_category not in return_list:
-                return_list[each_category] = {}
+                return_list["error_list"][each_category] = {}
             for each_error_type in self.category_list[each_category]:
-                return_list[each_category][each_error_type] = len(self.category_list[each_category][each_error_type])
+                error_count = len(self.category_list[each_category][each_error_type])
+                return_list["error_list"][each_category][each_error_type] = error_count
+                total_errors += error_count
 
-
+        return_list["total_errors"] = total_errors
         return return_list
 
 

--- a/object_class.py
+++ b/object_class.py
@@ -3857,7 +3857,7 @@ class BlockExtractor:
 
         return None
 
-    def get_all_content(self):
+    def get_all_contentX(self):
         """
         Return all content as text to be able to serialize it
         :return:
@@ -3871,6 +3871,22 @@ class BlockExtractor:
                 return_content[each_type][each_content] = list()
                 for each_detail in self.get_reference(each_content, each_type):
                     return_content[each_type][each_content].append("".join(each_detail.get_content()))
+
+        return return_content
+
+    def get_all_content(self):
+        """
+        Return all content as text to be able to serialize it
+        :return:
+        """
+
+        return_content = {}
+
+        for each_type in self.get_reference():
+            return_content[each_type] = {}
+            for each_content in self.get_reference(None, each_type):
+                for each_detail in self.get_reference(each_content, each_type):
+                    return_content[each_type][each_content] = convert_into_dict(each_detail)
 
         return return_content
 
@@ -4085,6 +4101,27 @@ class TimeoutError(Exception):
             signal.alarm(0)
             signal.signal(signal.SIGALRM, old_handler)
 
+def convert_into_dict(obj):
+    """
+    Convert given object into a readable dictionary, for serialization
+    :param obj: class/object to convert
+    :return: a dictionary or object required for serialization
+    """
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    if isinstance(obj, dict):
+        return {k: convert_into_dict(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [convert_into_dict(x) for x in obj]
+
+    # Aquí aplicamos tu filtro para objetos personalizados
+    if hasattr(obj, "__dict__"):
+        return {
+            k: convert_into_dict(v)
+            for k, v in vars(obj).items()
+            if not callable(v) and not k.startswith('_')
+        }
+    return str(obj) # Último recurso
 
 def get_not_null(list_or_tuple, start=0):
     """

--- a/test_api.py
+++ b/test_api.py
@@ -3,7 +3,8 @@ import json
 import drivers.yaml_driver
 from core import analyze_corda_log, DataInfo
 from drivers.yaml_driver import YamlDataDriver
-from object_class import CordaObject
+from object_class import CordaObject, Error, Party
+
 
 # Tests:
 # pull a list of:
@@ -14,21 +15,13 @@ from object_class import CordaObject
 # TODO: everytime it ran it "forgets" about what was analysed, this will prevent analysis of specific flows or tx
 #       I need to include a method to "save" what was collected so program has something to look at
 
-datainfo = DataInfo()
-datainfo.set(DataInfo.Attribute.CUSTOMER, "test-customer")
-datainfo.set(DataInfo.Attribute.TICKET, "TST-0000")
 
-#result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/NCR/CS-4189/2026-03-10-11-prd-api-service.log",
-result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/tests-logs/insuree.log",
-                           [CordaObject.Type.ERROR_ANALYSIS, CordaObject.Type.FLOW_AND_TRANSACTIONS, CordaObject.Type.PARTY],
-                           datainfo)
-#result = analyze_corda_log("client-logs/ChainThat/CS-4002/party005-dev-corda-logs.txt")
 
 
 def save_analysis(result, object_type=None):
     """
     Store analysis.
-    :param object_type:
+    :param object_type: What to persist from API response...
     :return:
     """
 
@@ -37,37 +30,81 @@ def save_analysis(result, object_type=None):
             CordaObject.Type.FLOW_AND_TRANSACTIONS,
             CordaObject.Type.PARTY,
             CordaObject.Type.ERROR_ANALYSIS,
+            CordaObject.Type.SPECIAL_BLOCKS
         ]
 
+    if not isinstance(object_type, list):
+       object_type = [object_type]
+
+    customer = datainfo.get(DataInfo.Attribute.CUSTOMER)
+    ticket = datainfo.get(DataInfo.Attribute.TICKET)
+    storage = YamlDataDriver()
+    summary = {
+        "analysis": result["summary"]
+    }
+    storage.connect(data_dir= f"./data/storage/{customer}/{ticket}", summary=summary)
+
     for each_object in object_type:
-        storage = YamlDataDriver()
+        if each_object == CordaObject.Type.ERROR_ANALYSIS and each_object.value in result["results"]:
+            category = result["results"][each_object.value]
+            for each_item_category in category:
+                for each_error in category[each_item_category]:
+                    error_list = category[each_item_category][each_error]
+                    for each_item in error_list:
+                        # error = Error()
+                        # error.category = each_item_category
+                        # error.type = each_item["type"]
+                        # error.level = each_item["level"]
+                        # error.line_number = each_item['line_number']
+                        # error.timestamp = each_item['timestamp']
+                        # error.reference_id = each_item['line_number']
+                        # error.log_line = each_item["log_line"]
+                        if 'category' not in each_item:
+                            each_item['category'] = each_item_category
+                        if 'reference_id' not in each_item:
+                            each_item['reference_id'] = each_item['line_number']
 
-        customer = datainfo.get(DataInfo.Attribute.CUSTOMER)
-        ticket = datainfo.get(DataInfo.Attribute.TICKET)
+                        storage.save_error(each_item)
 
-        if each_object == CordaObject.Type.ERROR_ANALYSIS:
-            config = {
-               'data_dir': f"./data/storage/{customer}/{ticket}",
-               'cache_enabled': True
-            }
+        if each_object == CordaObject.Type.PARTY and each_object.value in result["results"]:
+            for each_party in result['results'][each_object.value]:
+                party = Party(each_party['name'])
+                party.set_corda_role('/'.join(each_party['roles']))
+                # storage.save_party(each_party)
+                storage.save_party(party)
 
-            storage.connect(config)
+        if each_object == CordaObject.Type.FLOW_AND_TRANSACTIONS and each_object.value in result["results"]:
+            object_list = result['results'][each_object.value]
+            for each_item in object_list:
+                # co = CordaObject()
+                # co.from_dict(object_list[each_item])
+                storage.save_corda_object(object_list[each_item])
 
-            for each_item in result["result"][each_object]:
-
-
-
-
-
-
-
-
-
-    pass
-
-
+        if each_object == CordaObject.Type.SPECIAL_BLOCKS and each_object.value in result["results"]:
+            block_type_list = result['results'][CordaObject.Type.SPECIAL_BLOCKS.value]['collected_blocktypes']
+            for each_block_type in block_type_list:
+                for each_block in block_type_list[each_block_type]:
+                    storage.save_block_item(block_type_list[each_block_type][each_block])
+    storage.disconnect()
 
 
 
 
-print(json.dumps(result, indent=2))
+if __name__ == "__main__":
+    datainfo = DataInfo()
+    datainfo.set(DataInfo.Attribute.CUSTOMER, "test-customer")
+    datainfo.set(DataInfo.Attribute.TICKET, "TST-0000")
+    datainfo.set(DataInfo.Attribute.CORDA_VERSION, "4.9")
+    datainfo.set(datainfo.Attribute.ENVIRONMENT, "UAT")
+    datainfo.set(datainfo.Attribute.ISSUE, "Testing logs")
+    datainfo.set(datainfo.Attribute.DESCRIPTION, "This is just for logs testing API")
+
+    #result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/NCR/CS-4189/2026-03-10-11-prd-api-service.log",
+    # result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/tests-logs/insuree.log",
+    # result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/ChainThat/CS-4002/mnp-dev-party005-cordanode-7.log",
+    result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/HQLAx/CS-4163/hqlx.log",
+                               datainfo=datainfo)
+    #result = analyze_corda_log("client-logs/ChainThat/CS-4002/party005-dev-corda-logs.txt")
+    #save_analysis(result, CordaObject.Type.ERROR_ANALYSIS)
+    save_analysis(result)
+    print(json.dumps(result, indent=2))


### PR DESCRIPTION
-- Added autodetection of object to persist, required object must be a dictionary to be able to serialize it, but if an specific object class is sent program will convert such object into a dictionary for persistence.
- Added support to collect errors
- Also added support to different object classes to persist.
- Added a summary for persistence.
- Add support to add important information about customer and file analysed