### PR TITLE
Fix issue #33: modify payload structure from api response and saving data to support multiple logs on same ticket

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,4 +1,5 @@
 # logtracer/core.py
+import hashlib
 import threading
 from enum import Enum
 
@@ -21,6 +22,7 @@ class CoreApi:
         self.result = None
         self.datainfo = datainfo
         self.log_file_path = None
+        self.log_files = []
         self.what_to_collect = None
         self.references_id = None
         self.file_to_analyse = None
@@ -43,12 +45,15 @@ class CoreApi:
             }
         return str(obj) # Último recurso
 
-    def set_log_file(self, logfile):
+    def add_log_file(self, logfile):
         """
 
         :param logfile:
         :return:
         """
+
+        self.log_files.append(logfile)
+
         self.log_file_path = logfile
 
     def what_to_collect(self, what_to_collect:CordaObject.Type=None):
@@ -66,8 +71,6 @@ class CoreApi:
         :return:
         """
         self.references_id = references_id
-
-
 
     def get_results(self):
         """
@@ -91,14 +94,14 @@ class CoreApi:
             what_to_collect = [self.what_to_collect]
 
         Configs.load_config()
+        master_payload = {'log_files': {}}
+        file_index = {}
         payload = {
-            "summary":{
-                "log_file": self.log_file_path
-            },
+            "summary":{},
             "results": {}
         }
-        if self.datainfo:
-            payload["summary"]["file_info"] = self.datainfo.get_all()
+        # if self.datainfo:
+        #     payload["summary"]["file_info"] = self.datainfo.get_all()
 
         KnownErrors.configs = Configs
         KnownErrors.initialize()
@@ -108,107 +111,120 @@ class CoreApi:
         customer_path =f"{os.path.dirname(os.path.abspath(__file__))}/{data_dir}"
 
         # 1. Configurar archivo
-        self.file_to_analyse = FileManagement(self.log_file_path, block_size_in_mb=15)
+        # need to loop in all assigned files
+        for each_file in self.log_files:
+            self.file_to_analyse = FileManagement(each_file, block_size_in_mb=15)
+            if not self.file_to_analyse.state:
+                raise ValueError(f"Unable to to read given file due to: {self.file_to_analyse.state_message}")
+            self.log_file_path = each_file
+            payload['summary']['log_file'] = each_file
+            self.file_to_analyse.discover_file_format()
+            payload["summary"]["file_version_used"] = self.file_to_analyse.logfile_format
+            special_blocks = None
+            collect_parties = None
+            collect_refIds = None
+            collect_errors = None
 
-        if not self.file_to_analyse.state:
-            raise ValueError(f"Unable to to read given file due to: {self.file_to_analyse.state_message}")
+            if not self.what_to_collect or CordaObject.Type.SPECIAL_BLOCKS in  self.what_to_collect:
+                # 2. Extraer bloques especiales (opcional, si los necesitas en la API)
+                special_blocks = BlockExtractor(self.file_to_analyse, Configs.config)
+                special_blocks.extract()
 
-        self.file_to_analyse.discover_file_format()
-        payload["summary"]["file-version-used"] = self.file_to_analyse.logfile_format
-        special_blocks = None
-        collect_parties = None
-        collect_refIds = None
-        collect_errors = None
+            if not self.what_to_collect or CordaObject.Type.PARTY in self.what_to_collect:
+                # 3. Configurar recolectores
+                #
+                # Party collection
+                collect_parties = GetParties(Configs)
+                collect_parties.set_file(self.file_to_analyse)
+                collect_parties.set_element_type(CordaObject.Type.PARTY)
+                self.file_to_analyse.add_process_to_execute(collect_parties)
 
-        if not self.what_to_collect or CordaObject.Type.SPECIAL_BLOCKS in  self.what_to_collect:
-            # 2. Extraer bloques especiales (opcional, si los necesitas en la API)
-            special_blocks = BlockExtractor(self.file_to_analyse, Configs.config)
-            special_blocks.extract()
+            if not self.what_to_collect or CordaObject.Type.FLOW_AND_TRANSACTIONS in self.what_to_collect:
+                #
+                # Transactions and Flows collection
+                collect_refIds = GetRefIds(Configs)
+                collect_refIds.set_file(self.file_to_analyse)
+                collect_refIds.set_element_type(CordaObject.Type.FLOW_AND_TRANSACTIONS)
+                self.file_to_analyse.add_process_to_execute(collect_refIds)
 
-        if not self.what_to_collect or CordaObject.Type.PARTY in self.what_to_collect:
-            # 3. Configurar recolectores
-            #
-            # Party collection
-            collect_parties = GetParties(Configs)
-            collect_parties.set_file(self.file_to_analyse)
-            collect_parties.set_element_type(CordaObject.Type.PARTY)
-            self.file_to_analyse.add_process_to_execute(collect_parties)
+            if not self.what_to_collect or CordaObject.Type.ERROR_ANALYSIS in self.what_to_collect:
+                #
+                # Collection of Errors
+                collect_errors = ErrorAnalysis(Configs.config)
+                collect_errors.set_file(self.file_to_analyse)
+                collect_errors.set_element_type(CordaObject.Type.ERROR_ANALYSIS)
+                self.file_to_analyse.add_process_to_execute(collect_errors)
 
-        if not self.what_to_collect or CordaObject.Type.FLOW_AND_TRANSACTIONS in self.what_to_collect:
-            #
-            # Transactions and Flows collection
-            collect_refIds = GetRefIds(Configs)
-            collect_refIds.set_file(self.file_to_analyse)
-            collect_refIds.set_element_type(CordaObject.Type.FLOW_AND_TRANSACTIONS)
-            self.file_to_analyse.add_process_to_execute(collect_refIds)
+            # 4. Ejecutar procesamiento
+            self.file_to_analyse.pre_analysis()
+            self.file_to_analyse.parallel_processing()
 
-        if not self.what_to_collect or CordaObject.Type.ERROR_ANALYSIS in self.what_to_collect:
-            #
-            # Collection of Errors
-            collect_errors = ErrorAnalysis(Configs.config)
-            collect_errors.set_file(self.file_to_analyse)
-            collect_errors.set_element_type(CordaObject.Type.ERROR_ANALYSIS)
-            self.file_to_analyse.add_process_to_execute(collect_errors)
+            # Si quieres soportar múltiples roles por party:
+            if collect_parties:
+                # 1. Obtener todos los roles detectados en el log
+                detected_roles = self.file_to_analyse.get_party_role()
 
-        # 4. Ejecutar procesamiento
-        self.file_to_analyse.pre_analysis()
-        self.file_to_analyse.parallel_processing()
+                x500_to_roles = {}
+                for role in detected_roles:
+                    for x500 in (self.file_to_analyse.get_party_role(role) or []):
+                        x500_to_roles.setdefault(x500, []).append(role)
 
-        # Si quieres soportar múltiples roles por party:
-        if collect_parties:
-            # 1. Obtener todos los roles detectados en el log
-            detected_roles = self.file_to_analyse.get_party_role()
+                parties = [
+                    {"name": p.name, "roles": x500_to_roles.get(p.name, [])}
+                    for p in self.file_to_analyse.get_all_unique_results(CordaObject.Type.PARTY, True) or []
+                ]
+                payload["summary"]["total_parties"] = len(parties)
+                payload["summary"]["detected_roles"] = detected_roles
+                payload["results"][CordaObject.Type.PARTY.value] = parties
 
-            x500_to_roles = {}
-            for role in detected_roles:
-                for x500 in (self.file_to_analyse.get_party_role(role) or []):
-                    x500_to_roles.setdefault(x500, []).append(role)
+            if collect_refIds:
+                flows = {}
+                transactions = {}
+                # Transform CordaObject into a dictionary for serialization
+                for item in self.file_to_analyse.get_all_unique_results(CordaObject.Type.FLOW_AND_TRANSACTIONS, True) or []:
+                    ref_id = item.get_reference_id()
+                    item_dict = self.deep_to_dict(item)
+                    if item.get_type() == "FLOW":
+                        flows[f'{ref_id}']=item_dict
+                    elif item.get_type() == "TRANSACTION":
+                        transactions[f'{ref_id}'] =item_dict
+                # Put all content of flows and transactions into same bucket; each corda object has its type and can be
+                # easily identified.
+                fnt = {**flows, **transactions}
+                payload["summary"]["total_transactions"] = len(transactions)
+                payload["summary"]["total_flows"]= len(flows)
 
-            parties = [
-                {"name": p.name, "roles": x500_to_roles.get(p.name, [])}
-                for p in self.file_to_analyse.get_all_unique_results(CordaObject.Type.PARTY, True) or []
-            ]
-            payload["summary"]["total_parties"] = len(parties)
-            payload["summary"]["detected_roles"] = detected_roles
-            payload["results"][CordaObject.Type.PARTY.value] = parties
+                payload["results"][CordaObject.Type.FLOW_AND_TRANSACTIONS.value] = fnt
 
-        if collect_refIds:
-            flows = {}
-            transactions = {}
-            # Transform CordaObject into a dictionary for serialization
-            for item in self.file_to_analyse.get_all_unique_results(CordaObject.Type.FLOW_AND_TRANSACTIONS, True) or []:
-                ref_id = item.get_reference_id()
-                item_dict = self.deep_to_dict(item)
-                if item.get_type() == "FLOW":
-                    flows[f'{ref_id}']=item_dict
-                elif item.get_type() == "TRANSACTION":
-                    transactions[f'{ref_id}'] =item_dict
-            # Put all content of flows and transactions into same buket; each corda object has its type and can be
-            # easily identified.
-            fnt = {**flows, **transactions}
-            payload["summary"]["total_transactions"] = len(transactions)
-            payload["summary"]["total_flows"]= len(flows)
+            if special_blocks and  special_blocks.collected_blocks:
+                payload["results"][CordaObject.Type.SPECIAL_BLOCKS.value] = {
+                    "collected_blocktypes_types": special_blocks.get_collected_block_types(),
+                    "defined_blocktypes": special_blocks.get_defined_block_types(),
+                    "collected_blocktypes": special_blocks.get_all_content()
+                }
+                payload['summary'][CordaObject.Type.SPECIAL_BLOCKS.value] = special_blocks.get_collected_block_types()
 
-            payload["results"][CordaObject.Type.FLOW_AND_TRANSACTIONS.value] = fnt
-
-        if special_blocks and  special_blocks.collected_blocks:
-            payload["results"][CordaObject.Type.SPECIAL_BLOCKS.value] = {
-                "collected_blocktypes_types": special_blocks.get_collected_block_types(),
-                "defined_blocktypes": special_blocks.get_defined_block_types(),
-                "collected_blocktypes": special_blocks.get_all_content()
+            if collect_errors:
+                collect_errors.collected_errors = self.file_to_analyse.get_all_unique_results(CordaObject.Type.ERROR_ANALYSIS)
+                # payload["Error-log"] = collect_errors.get_error_category()
+                payload["results"][CordaObject.Type.ERROR_ANALYSIS.value] = collect_errors.get_all_content()
+                payload['summary'][CordaObject.Type.ERROR_ANALYSIS.value] = collect_errors.get_error_summary()
+            file_index[self.file_to_analyse.file_id] = self.log_file_path
+            payload['summary']['file_info'] = {
+                'processed_timestamp': self.file_to_analyse.load_timestamp,
+                'file_size': self.file_to_analyse.file_size
             }
-            payload['summary'][CordaObject.Type.SPECIAL_BLOCKS.value] = special_blocks.get_collected_block_types()
 
-        if collect_errors:
-            collect_errors.collected_errors = self.file_to_analyse.get_all_unique_results(CordaObject.Type.ERROR_ANALYSIS)
-            # payload["Error-log"] = collect_errors.get_error_category()
-            payload["results"][CordaObject.Type.ERROR_ANALYSIS.value] = collect_errors.get_all_content()
-            payload['summary'][CordaObject.Type.ERROR_ANALYSIS.value] = collect_errors.get_error_summary()
+            master_payload['log_files'][self.file_to_analyse.file_id] = payload
+            # 6. Devolver resultado estructurado
+        # self.datainfo.set('log_files', file_index)
+        master_payload['ticket_details'] = self.datainfo.get_all()
 
 
-        # 6. Devolver resultado estructurado
-        self.result = payload
-        return payload
+        self.result = master_payload
+
+
+        return master_payload
 
     def save_analysis(self, object_type=None, driver=None):
         """
@@ -235,53 +251,59 @@ class CoreApi:
             ticket = self.datainfo.get(DataInfo.Attribute.TICKET) or "unknown"
 
             storage = YamlDataDriver()
-            summary = {
-                "analysis": self.result["summary"]
-            }
-            storage.connect(data_dir= f"./data/storage/{customer}/{ticket}", summary=summary)
 
-            for each_object in object_type:
-                if each_object == CordaObject.Type.ERROR_ANALYSIS and each_object.value in self.result["results"]:
-                    category = self.result["results"][each_object.value]
-                    for each_item_category in category:
-                        for each_error in category[each_item_category]:
-                            error_list = category[each_item_category][each_error]
-                            for each_item in error_list:
-                                # error = Error()
-                                # error.category = each_item_category
-                                # error.type = each_item["type"]
-                                # error.level = each_item["level"]
-                                # error.line_number = each_item['line_number']
-                                # error.timestamp = each_item['timestamp']
-                                # error.reference_id = each_item['line_number']
-                                # error.log_line = each_item["log_line"]
-                                if 'category' not in each_item:
-                                    each_item['category'] = each_item_category
-                                if 'reference_id' not in each_item:
-                                    each_item['reference_id'] = each_item['line_number']
+            if 'log_files' in self.result:
+                for file_id in  self.result['log_files']:
+                    summary = {
+                        "analysis": self.result['log_files'][file_id]["summary"]
+                    }
+                    storage.connect(data_dir= f"./data/storage/{customer}/{ticket}/{file_id}",
+                                    summary=summary,
+                                    ticket_details=self.result['ticket_details'])
 
-                                storage.save_error(each_item)
+                    for each_object in object_type:
+                        if each_object == CordaObject.Type.ERROR_ANALYSIS and each_object.value in self.result['log_files'][file_id]["results"]:
+                            category = self.result['log_files'][file_id]["results"][each_object.value]
+                            for each_item_category in category:
+                                for each_error in category[each_item_category]:
+                                    error_list = category[each_item_category][each_error]
+                                    for each_item in error_list:
+                                        # error = Error()
+                                        # error.category = each_item_category
+                                        # error.type = each_item["type"]
+                                        # error.level = each_item["level"]
+                                        # error.line_number = each_item['line_number']
+                                        # error.timestamp = each_item['timestamp']
+                                        # error.reference_id = each_item['line_number']
+                                        # error.log_line = each_item["log_line"]
+                                        if 'category' not in each_item:
+                                            each_item['category'] = each_item_category
+                                        if 'reference_id' not in each_item:
+                                            each_item['reference_id'] = each_item['line_number']
 
-                if each_object == CordaObject.Type.PARTY and each_object.value in self.result["results"]:
-                    for each_party in self.result['results'][each_object.value]:
-                        party = Party(each_party['name'])
-                        party.set_corda_role('/'.join(each_party['roles']))
-                        # storage.save_party(each_party)
-                        storage.save_party(party)
+                                        storage.save_error(each_item)
 
-                if each_object == CordaObject.Type.FLOW_AND_TRANSACTIONS and each_object.value in self.result["results"]:
-                    object_list = self.result['results'][each_object.value]
-                    for each_item in object_list:
-                        # co = CordaObject()
-                        # co.from_dict(object_list[each_item])
-                        storage.save_corda_object(object_list[each_item])
+                        if each_object == CordaObject.Type.PARTY and each_object.value in self.result['log_files'][file_id]["results"]:
+                            for each_party in self.result['log_files'][file_id]['results'][each_object.value]:
+                                party = Party(each_party['name'])
+                                party.set_corda_role('/'.join(each_party['roles']))
+                                # storage.save_party(each_party)
+                                storage.save_party(party)
 
-                if each_object == CordaObject.Type.SPECIAL_BLOCKS and each_object.value in self.result["results"]:
-                    block_type_list = self.result['results'][CordaObject.Type.SPECIAL_BLOCKS.value]['collected_blocktypes']
-                    for each_block_type in block_type_list:
-                        for each_block in block_type_list[each_block_type]:
-                            storage.save_block_item(block_type_list[each_block_type][each_block])
-            storage.disconnect()
+                        if each_object == CordaObject.Type.FLOW_AND_TRANSACTIONS and each_object.value in self.result['log_files'][file_id]["results"]:
+                            object_list = self.result['log_files'][file_id]['results'][each_object.value]
+                            for each_item in object_list:
+                                # co = CordaObject()
+                                # co.from_dict(object_list[each_item])
+                                storage.save_corda_object(object_list[each_item])
+
+                        if each_object == CordaObject.Type.SPECIAL_BLOCKS and each_object.value in self.result['log_files'][file_id]["results"]:
+                            block_type_list = self.result['log_files'][file_id]['results'][CordaObject.Type.SPECIAL_BLOCKS.value]['collected_blocktypes']
+                            for each_block_type in block_type_list:
+                                for each_block in block_type_list[each_block_type]:
+                                    storage.save_block_item(block_type_list[each_block_type][each_block])
+
+                    storage.disconnect()
 
     def load_analysis(self):
         """
@@ -296,7 +318,20 @@ class CoreApi:
 
         storage.load_data()
 
+    def get_file_hash(self, chunk_size=65536):
+        """
+        Genera un hash SHA-256 del contenido del archivo.
+        Si el contenido es idéntico, el hash será idéntico.
+        """
+        hasher = hashlib.sha256()
 
+        with open(self.log_file_path, 'rb') as f:
+            # Leemos el archivo en bloques (chunks) para no cargar logs gigas en RAM
+            while chunk := f.read(chunk_size):
+                hasher.update(chunk)
+
+        # 16 caracteres son más que suficientes para evitar colisiones en este contexto
+        return hasher.hexdigest()[:16]
 
     def get_analysis_for(self, log_file_path: str, reference_id: str):
         """
@@ -508,3 +543,7 @@ class DataInfo:
         """
 
         return self.data
+
+class Payload:
+
+    pass

--- a/data_interface.py
+++ b/data_interface.py
@@ -137,3 +137,13 @@ class DataDriver(ABC):
     def get_errors_by_category_type(self):
         """Get a specific error by its category and type"""
         pass
+
+    @abstractmethod
+    def save_details(self):
+        """Save ticket details"""
+        pass
+
+    @abstractmethod
+    def save_summary(self):
+        """save file summary analysis"""
+        pass

--- a/drivers/yaml_driver.py
+++ b/drivers/yaml_driver.py
@@ -23,6 +23,8 @@ class YamlDataDriver(DataDriver):
         self.blocks_dir = None
         self.errors_dir = None
         self.summary = None
+        self.ticket_details = None
+        self.logfile_hash = None
         self.cache = {}  # Opcional: cache para mejorar rendimiento
 
     def connect(self, **config):
@@ -44,6 +46,7 @@ class YamlDataDriver(DataDriver):
         self.blocks_dir = self.data_dir / "blocks"
         self.errors_dir = self.data_dir / "errors"
         self.summary = config.get("summary")
+        self.ticket_details = config.get("ticket_details", None)
 
         if not only_list:
             # Crear directorios
@@ -57,6 +60,8 @@ class YamlDataDriver(DataDriver):
 
         if self.summary:
            self.save_summary()
+        if self.ticket_details:
+            self.save_details()
 
     def load_data(self):
         """
@@ -298,6 +303,13 @@ class YamlDataDriver(DataDriver):
         with open(f"{self.data_dir}/summary.yaml", 'w', encoding='utf-8') as f:
             yaml.dump(self.summary, f, allow_unicode=True, default_flow_style=False)
 
+    def save_details(self):
+        """
+        Save ticket details for received payload
+        :return:
+        """
+        with open(f"{self.data_dir}/../ticket_details.yaml", 'w', encoding='utf-8') as f:
+            yaml.dump(self.ticket_details, f, allow_unicode=True, default_flow_style=False)
 
     def save_block_item(self, block_item):
 

--- a/object_class.py
+++ b/object_class.py
@@ -3,6 +3,8 @@ import hashlib
 import json
 import mmap
 import os,time
+from datetime import datetime
+
 import regex as re
 import threading
 from collections import OrderedDict
@@ -1241,6 +1243,10 @@ class FileManagement:
         self.log_line_fields = None
         self.state = None
         self.state_message = None
+        self.load_timestamp = None
+        self.file_id = None
+        self.time_spent = None
+
 
         if not os.path.exists(self.filename):
             write_log("Unable to open given filename, it doesn't exist", level="ERROR")
@@ -1506,7 +1512,9 @@ class FileManagement:
 
     def pre_analysis(self):
         try:
+            self.file_id = hashlib.sha256()
             file_size = os.path.getsize(self.filename)
+            self.file_size = file_size
             fsize = file_size / 1024 / 1024
             bsize = self.block_size / 1024 / 1024
             write_log(f'Block size for reading: {bsize:.2f} Mbytes')
@@ -1528,6 +1536,7 @@ class FileManagement:
                     # Si estamos cerca del final y el resto es menor al porcentaje mínimo, fusionamos
                     if remaining < (self.block_size * self.min_percent_merge / 100):
                         chunk = file.read(remaining)
+                        self.file_id.update(chunk.encode('utf-8', errors='ignore'))
                         last_newline = chunk.rfind('\n')
                         if last_newline != -1:
                             end_pos = start_pos + last_newline + 1
@@ -1552,6 +1561,7 @@ class FileManagement:
                     else:
                         # Leer bloque normal
                         chunk = file.read(self.block_size)
+                        self.file_id.update(chunk.encode('utf-8', errors='ignore'))
                         last_newline = chunk.rfind('\n')
                         if last_newline != -1:
                             end_pos = start_pos + last_newline + 1
@@ -1566,6 +1576,8 @@ class FileManagement:
                         file.seek(end_pos)
 
                         write_log(f"Processed block: start_pos={start_pos}, lines={start_line}-{end_line}")
+            self.file_id = self.file_id.hexdigest()[:16]
+            write_log(f'File Hash ID: {self.file_id}')
             write_log(f'Will launch {len(self.chunk_info)} threads to read full file...')
             self.state = True
 
@@ -1734,7 +1746,6 @@ class FileManagement:
                     else:
                         schedule_ui_update('TTkLabel_analysis_stat', "setText", '\u2705 Done...')
 
-
                 # Programar próxima verificación
                 if active_tasks and not shutdown_event.is_set():
                     threading.Timer(0.1, monitor_tasks).start()  # ¡Solo 100ms!
@@ -1774,7 +1785,9 @@ class FileManagement:
 
             if self.debug:
                 write_log(f"{Icons.SUCCESS} Analysis complete. "
-                          f"Total: {total_data:.2f} MB en {total_time:.2f}s")
+                          f"Total: {total_data:.2f} MB in {total_time:.2f}s")
+                self.load_timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                self.time_spent = f"Total: {total_data:.2f} MB in {total_time:.2f}s"
 
 
 

--- a/test_api.py
+++ b/test_api.py
@@ -11,14 +11,11 @@ from core import  DataInfo, CoreApi
 # TODO: everytime it ran it "forgets" about what was analysed, this will prevent analysis of specific flows or tx
 #       I need to include a method to "save" what was collected so program has something to look at
 
-def test_analysis(datainfo, log_path):
+def test_analysis(analysis):
     """
     Saving test
     :return:
     """
-
-    analysis = CoreApi(datainfo)
-    analysis.set_log_file(log_path)
 
     #result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/NCR/CS-4189/2026-03-10-11-prd-api-service.log",
     # result = analyze_corda_log("/home/larry/IdeaProjects/logtracer/c4-logs/tests-logs/insuree.log",
@@ -62,25 +59,31 @@ def test_load(datainfo):
 
 if __name__ == "__main__":
     analysis_test = None
-    if False:
+    if True:
         datainfo = DataInfo()
-        datainfo.set(DataInfo.Attribute.CUSTOMER, "Nexi Payments")
-        datainfo.set(DataInfo.Attribute.TICKET, "CS-4105")
+        datainfo.set(DataInfo.Attribute.CUSTOMER, "test-customer")
+        datainfo.set(DataInfo.Attribute.TICKET, "TS-0001")
         datainfo.set(DataInfo.Attribute.CORDA_VERSION, "4.11.5")
-        datainfo.set(datainfo.Attribute.ENVIRONMENT, "Production")
-        datainfo.set(datainfo.Attribute.ISSUE, "Notary worker crash")
-        datainfo.set(datainfo.Attribute.DESCRIPTION, "Notary cluster Crash")
+        datainfo.set(datainfo.Attribute.ENVIRONMENT, "UAT")
+        datainfo.set(datainfo.Attribute.ISSUE, "Test logs")
+        datainfo.set(datainfo.Attribute.DESCRIPTION, "Testing log analysis")
         #test_analysis(datainfo, "/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/HQLAx/CS-4163/hqlx.log")
-        analysis_test = test_analysis(datainfo,"/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/Nexi Payments/CS-4105/oct/node-ascorda_Notary_01.2025-10-07-1.log")
 
-    if False:
+        analysis = CoreApi(datainfo)
+        # analysis.add_log_file("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/ChainThat/CS-4002/02-10-2025/Corda-Start-logs.log")
+        # analysis.add_log_file("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/ChainThat/CS-4002/02-10-2025/Success-Transaction-logs.log")
+        analysis.add_log_file("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/test-customer/observer.log")
+        analysis.add_log_file("/home/larry/IdeaProjects/logtracer/c4-logs/client-logs/test-customer/solutioneng.log")
+        analysis_test = test_analysis(analysis)
+
+    if True:
         if analysis_test:
             analysis_test.save_analysis()
 
-    if True:
+    if False:
         list_test()
 
-    if True:
+    if False:
         datainfo = DataInfo()
         datainfo.set(DataInfo.Attribute.CUSTOMER, "ChainThat")
         datainfo.set(DataInfo.Attribute.TICKET, "CS-4002")


### PR DESCRIPTION
add support to read and analyse multiple logs assigned to same ticket Change payload structure to hold multiple logs
Change summary to be hold inside every log file
Add new "ticket_details" to summarise all ticket information Add log_file has ids and save all analysis under each file id

Also saving all data with new structure supporting multiple logs